### PR TITLE
Switch network 

### DIFF
--- a/src/HomePage/Components/UnsupportedNetwork.jsx
+++ b/src/HomePage/Components/UnsupportedNetwork.jsx
@@ -1,7 +1,12 @@
-import React from "react";
+import React, { useContext } from "react";
+import {MetamaskContext, ropstenNetwork } from "../../Web3/";
+import { useNotification } from "../../Notification";
+
 import "../scss/UnsupportedNetwork.scss";
 
 export default function UnsupportedNetwork() {
+  const { switchNetwork } = useContext(MetamaskContext);
+  const { failedAlert } = useNotification();
   return (
     <div className="invalid-network-container">
       <div className="invalid-network-container__title">
@@ -9,7 +14,7 @@ export default function UnsupportedNetwork() {
         Unsupported Network
       </div>
       <div className="invalid-network-container__body">
-        Connect To Ropsten Testnet
+        <button onClick={() => switchNetwork(ropstenNetwork, failedAlert)}> Connect To Ropsten Testnet </button>
       </div>
     </div>
   );

--- a/src/HomePage/scss/UnsupportedNetwork.scss
+++ b/src/HomePage/scss/UnsupportedNetwork.scss
@@ -27,3 +27,4 @@
         font-size: 1rem;
     }
 }
+

--- a/src/Web3/ChainList/chainConfiguration.js
+++ b/src/Web3/ChainList/chainConfiguration.js
@@ -1,0 +1,10 @@
+const ropstenNetwork = {
+  method: "wallet_switchEthereumChain",
+  params: [
+    {
+      chainId: "0x3",
+    },
+  ],
+};
+
+export { ropstenNetwork };

--- a/src/Web3/ChainList/index.js
+++ b/src/Web3/ChainList/index.js
@@ -1,1 +1,2 @@
 export * from './chainList';
+export * from './chainConfiguration';

--- a/src/Web3/MetamaskAPI/Metamask.js
+++ b/src/Web3/MetamaskAPI/Metamask.js
@@ -94,10 +94,10 @@ export default function Metamask() {
     ethereum.removeListener(CHAIN_CHANGED, handleChainChanged);
   };
 
-  const addNewChain = (chainObject) => {
-    ethereum.request(chainObject);
-  }
-  
+  const switchChain = (chainObject, pendingMessage) => {
+    ethereum.request(chainObject).then().catch((error) => pendingMessage ? pendingMessage("Please accept metamask request") : console.log(error));
+  };
+
   return {
     ethereum,
     getChainIdEthereum,
@@ -109,5 +109,6 @@ export default function Metamask() {
     setHandleRPCDisconnect,
     removeAccountsChanged,
     removeChainChanged,
+    switchChain,
   };
 }

--- a/src/Web3/MetamaskAPI/Metamask.js
+++ b/src/Web3/MetamaskAPI/Metamask.js
@@ -94,6 +94,10 @@ export default function Metamask() {
     ethereum.removeListener(CHAIN_CHANGED, handleChainChanged);
   };
 
+  const addNewChain = (chainObject) => {
+    ethereum.request(chainObject);
+  }
+  
   return {
     ethereum,
     getChainIdEthereum,

--- a/src/Web3/context/MetamaskProvider.jsx
+++ b/src/Web3/context/MetamaskProvider.jsx
@@ -95,6 +95,7 @@ function MetamaskProvider({ children }) {
     setHandleChainChanged,
     removeAccountsChanged,
     removeChainChanged,
+    switchChain,
   } = Metamask();
 
   useEffect(() => {
@@ -146,6 +147,10 @@ function MetamaskProvider({ children }) {
     removeChainChanged(onChainChangedCB);
   };
 
+  const switchNetwork = (network, pendingMessage) => {
+    switchChain(network, pendingMessage);
+  };
+
   const getProvider = () => {
     return provider;
   };
@@ -155,8 +160,8 @@ function MetamaskProvider({ children }) {
   };
 
   const getValidNetwork = () => {
-      return validNetwork;
-  }
+    return validNetwork;
+  };
 
   return (
     <MetamaskContext.Provider
@@ -172,6 +177,7 @@ function MetamaskProvider({ children }) {
         setOnEthereumNotDetected,
         connectToMetamask,
         disconnectFromMetamask,
+        switchNetwork,
       }}
     >
       {children}


### PR DESCRIPTION
Made it possible to switch to Ropsten testnet network:
- Added switchChain method to custom Metamask API
- Added switchNetwork to Metamask context provider
- Button to switch to Ropsten network
- Configuration files to allow new networks to be added